### PR TITLE
Fix links when in child directories

### DIFF
--- a/plugin/vim-github-links.vim
+++ b/plugin/vim-github-links.vim
@@ -5,7 +5,7 @@ function! GithubLink()
   let repo_name = system("http_true=$(git remote -v|grep http >/dev/null;echo $?); if [ $http_true == 0 ]; then git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"; else git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub(':', '/').gsub('.git', '').strip\"; fi")
   let filename = bufname("%")
   let linenumber = line(".")
-  let url = 'https://' . repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
+  let url = repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
   let output = system('pbcopy', url)
   return url
 endfunction

--- a/plugin/vim-github-links.vim
+++ b/plugin/vim-github-links.vim
@@ -1,10 +1,10 @@
 " My function to create github links for the current line of code
 function! GithubLink()
   let git_branch = system("git status | awk '/On branch/ {print $3}'| ruby -e 'print gets.strip'")
-  let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub(':', '/').gsub('.git', '').strip\"")
+  let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"")
   let filename = bufname("%")
   let linenumber = line(".")
-  let url = 'https://' . repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
+  let url = repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
   let output = system('pbcopy', url)
   return url
 endfunction

--- a/plugin/vim-github-links.vim
+++ b/plugin/vim-github-links.vim
@@ -5,7 +5,8 @@ function! GithubLink()
   let repo_name = system("http_true=$(git remote -v|grep http >/dev/null;echo $?); if [ $http_true == 0 ]; then git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"; else git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub(':', '/').gsub('.git', '').strip\"; fi")
   let filename = bufname("%")
   let linenumber = line(".")
-  let url = repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
+  let nested_directories = system('export PROJECT_GIT_DIR=$(git rev-parse --show-toplevel);pwd|sed "s|$PROJECT_GIT_DIR||"|tr -d "[:space:]"')
+  let url = repo_name . '/blob/' . git_branch . nested_directories . '/' . filename . "#L" . linenumber
   let output = system('pbcopy', url)
   return url
 endfunction

--- a/plugin/vim-github-links.vim
+++ b/plugin/vim-github-links.vim
@@ -1,7 +1,8 @@
 " My function to create github links for the current line of code
 function! GithubLink()
   let git_branch = system("git status | awk '/On branch/ {print $3}'| ruby -e 'print gets.strip'")
-  let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"")
+  " let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"")
+  let repo_name = system("http_true=$(git remote -v|grep http >/dev/null;echo $?); if [ $http_true == 0 ]; then git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"; else git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub(':', '/').gsub('.git', '').strip\"; fi")
   let filename = bufname("%")
   let linenumber = line(".")
   let url = repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber

--- a/plugin/vim-github-links.vim
+++ b/plugin/vim-github-links.vim
@@ -1,10 +1,11 @@
+
 " My function to create github links for the current line of code
 function! GithubLink()
   let git_branch = system("git status | awk '/On branch/ {print $3}'| ruby -e 'print gets.strip'")
-  let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/.*@/, '').gsub('.git', '').strip\"")
+  let repo_name = system("git config --get remote.origin.url | ruby -e \"print gets.gsub(/https?:\/\//, '').gsub(/.*@/, '').gsub(':', '/').gsub('.git', '').strip\"")
   let filename = bufname("%")
   let linenumber = line(".")
-  let url = repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
+  let url = 'https://' . repo_name . '/blob/' . git_branch . '/' . filename . "#L" . linenumber
   let output = system('pbcopy', url)
   return url
 endfunction


### PR DESCRIPTION
This fixes the links if your current working directory is a child directory of the root git directory.
Previously this only worked if you stayed in the root git directory